### PR TITLE
adding patch dependency

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -44,6 +44,7 @@ RUN set -ex \
     openssl \
     openssl-dev \
     procps \
+    patch \
     readline-dev \
     tar \
     xz \


### PR DESCRIPTION
Builds failing due to `patch` not found.

![image](https://user-images.githubusercontent.com/14348948/114759902-5b3c6400-9d24-11eb-81f6-b54d915d3235.png)
